### PR TITLE
Adding cudaDeviceSynchronize in instlibs/utils/sassi_lazyallocator.hpp

### DIFF
--- a/instlibs/utils/sassi_lazyallocator.hpp
+++ b/instlibs/utils/sassi_lazyallocator.hpp
@@ -152,6 +152,8 @@ namespace sassi {
       }
       else if (cbid == CUPTI_RUNTIME_TRACE_CBID_cudaLaunch_v3020)
       {
+        cudaDeviceSynchronize();
+
         // Call the init_cb function only once. 
         if(!ld->valid_data) {
           ld->valid_data = true;


### PR DESCRIPTION
Added cudaDeviceSynchronize in the main CUPTI callback that handles launches. Without cudaDeviceSynchronize, I'm not able to access **managed** variables that are used by the GPU kernel from the user callback routine.
